### PR TITLE
feat: 管理者もmasterに直接push出来ないように

### DIFF
--- a/.github/workflows/code-rabbit.yml
+++ b/.github/workflows/code-rabbit.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
     branches-ignore:
       - master
       - main

--- a/.github/workflows/code-rabbit.yml
+++ b/.github/workflows/code-rabbit.yml
@@ -22,7 +22,6 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '[run review]') && github.event.issue.pull_request) ||　(github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '[run review]')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'release') && !contains(github.event.pull_request.title, 'Release'))
     timeout-minutes: 15
     steps:
       - uses: coderabbitai/openai-pr-reviewer@latest

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ https://blog.kinto-technologies.com/posts/2022-12-10-VSCodeDevContainer/
 reopen container を選ぶと.devcontainer に Dockerfile と devcontainer.json ができる。
 時間はかかるが勝手にdevcontainerが立ち上がる。
 ctrl+jとかすると勝手にコンテナ内部に入ってcondaもactivateされる。
+
+## branch protection ruleについて
+管理者は普通にprotectionをしてもpush出来てしまうらしい
+https://zenn.dev/snowcait/articles/42bb6b56c806da


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - `.devcontainer`でコンテナを再開する方法と、`ctrl+j`を使用してコンテナに入る際に`conda`が自動的にアクティブになる情報を追加しました。
  - ブランチ保護ルールに関する情報を追加し、保護を適用しても管理者は変更をプッシュできることを明記しました。

- **ワークフローの変更**
  - GitHubイベントタイプとそれに関連する条件をチェックする`concurrency`セクションの条件を削除しました。これには`issue_comment`や`pull_request`イベント、特定のプルリクエストのタイトル除外が含まれていました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->